### PR TITLE
Switched BlockReader to LendingIterator

### DIFF
--- a/src/archive_reader/tests.rs
+++ b/src/archive_reader/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::error::Result;
+use crate::LendingIterator;
 
 const fn zip_archive() -> &'static str {
     concat!(env!("CARGO_MANIFEST_DIR"), "/test_resources/test.zip")
@@ -87,7 +88,8 @@ fn test_read_by_blocks() -> Result<()> {
     ))?;
     let mut num_of_blocks = 0_usize;
     let mut total_size = 0_usize;
-    for block in archive.read_file_by_block("large.txt")? {
+    let mut blocks = archive.read_file_by_block("large.txt")?;
+    while let Some(block) = blocks.next() {
         let block = block?;
         num_of_blocks += 1;
         total_size += block.len();

--- a/src/lending_iter.rs
+++ b/src/lending_iter.rs
@@ -1,0 +1,6 @@
+pub trait LendingIterator {
+    type Item<'me>
+    where
+        Self: 'me;
+    fn next(&mut self) -> Option<Self::Item<'_>>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod archive_reader;
 mod error;
+mod lending_iter;
 mod libarchive;
 
 pub use crate::archive_reader::*;
+pub use lending_iter::LendingIterator;


### PR DESCRIPTION
* Created `LendingIterator` trait using GAT
* `BlockReader` implements `LendingIterator` to avoid extra heap allocations