### PR TITLE
Better encapsulation and safety guarantee for Entries

### DIFF
--- a/src/archive_reader/archive.rs
+++ b/src/archive_reader/archive.rs
@@ -133,9 +133,15 @@ impl Archive {
     /// one can obtain two things from each entry:
     ///   1. name
     ///   2. content
-    pub fn entries(&self) -> Result<impl Iterator<Item = Result<Entry>> + Send> {
+    pub fn entries<F>(&self, mut process: F) -> Result<()>
+    where
+        F: FnMut(&mut Entry) -> Result<()>,
+    {
         info!(r#"Archive::entries()"#);
-        self.list_entries()
+        for entry in self.list_entries()? {
+            process(&mut entry?)?
+        }
+        Ok(())
     }
 }
 

--- a/src/archive_reader/archive.rs
+++ b/src/archive_reader/archive.rs
@@ -133,15 +133,24 @@ impl Archive {
     /// one can obtain two things from each entry:
     ///   1. name
     ///   2. content
+    #[cfg(not(feature = "lending_iter"))]
     pub fn entries<F>(&self, mut process: F) -> Result<()>
     where
         F: FnMut(&mut Entry) -> Result<()>,
     {
-        info!(r#"Archive::entries()"#);
+        info!(r#"Archive::entries(process: _)"#);
         for entry in self.list_entries()? {
             process(&mut entry?)?
         }
         Ok(())
+    }
+
+    #[cfg(feature = "lending_iter")]
+    pub fn entries(
+        &self,
+    ) -> Result<impl for<'a> crate::LendingIterator<Item<'a> = Result<&'a mut Entry>>> {
+        info!(r#"Archive::entries()"#);
+        self.list_entries()
     }
 }
 

--- a/src/archive_reader/archive.rs
+++ b/src/archive_reader/archive.rs
@@ -127,8 +127,8 @@ impl Archive {
         Ok(BlockReader::new(entries))
     }
 
-    /// `entries` returns an iterator of `Entry`s.
-    /// Each `Entry` represents a file / dir in an archive.
+    /// `entries` iterates through each file / dir in the archive,
+    /// and passes the mutable references of the entries to the process closure.
     /// Using the functions provided on the `Entry` object,
     /// one can obtain two things from each entry:
     ///   1. name
@@ -145,6 +145,12 @@ impl Archive {
         Ok(())
     }
 
+    /// `entries` returns a lending iterator of `Entry`s.
+    /// Each `Entry` represents a file / dir in an archive.
+    /// Using the functions provided on the `Entry` object,
+    /// one can obtain two things from each entry:
+    ///   1. name
+    ///   2. content
     #[cfg(feature = "lending_iter")]
     pub fn entries(
         &self,

--- a/src/archive_reader/archive_tests.rs
+++ b/src/archive_reader/archive_tests.rs
@@ -126,13 +126,14 @@ fn test_read_by_blocks() -> Result<()> {
 
 #[test]
 fn test_file_names_from_entries() -> Result<()> {
-    let entries = Archive::open(zip_archive()).entries()?;
     let mut names = vec![];
-    for entry in entries {
-        names.push(
-            unsafe { entry?.file_name(|bytes| Some(String::from_utf8_lossy(bytes)))? }.to_string(),
-        );
-    }
+    Archive::open(zip_archive()).entries(|entry| {
+        let file_name = entry
+            .file_name(|bytes| Some(String::from_utf8_lossy(bytes)))?
+            .to_string();
+        names.push(file_name);
+        Ok(())
+    })?;
     let expected = [
         "content/",
         "content/first",
@@ -149,17 +150,16 @@ fn test_file_content_from_entries() -> Result<()> {
     #[cfg(feature = "lending_iter")]
     use crate::LendingIterator;
 
-    let entries = Archive::open(zip_archive()).entries()?;
     let mut all_content = vec![];
-    for entry in entries {
-        let entry = entry?;
+    Archive::open(zip_archive()).entries(|entry| {
         let mut content = Vec::<u8>::new();
-        let mut blocks = unsafe { entry.read_file_by_block() };
+        let mut blocks = entry.read_file_by_block();
         while let Some(block) = blocks.next() {
             content.extend(block?.iter())
         }
-        all_content.push(content)
-    }
+        all_content.push(content);
+        Ok(())
+    })?;
     let expected: Vec<&[u8]> = vec![b"", b"first\n", b"third\n", b"", b"second\n"];
     assert_eq!(expected, all_content);
     Ok(())
@@ -167,18 +167,15 @@ fn test_file_content_from_entries() -> Result<()> {
 
 #[test]
 fn test_entry_name_reproducible() -> Result<()> {
-    let entries = Archive::open(zip_archive()).entries()?;
     fn utf8_decoder(bytes: &[u8]) -> Option<Cow<str>> {
         Some(String::from_utf8_lossy(bytes))
     }
-    for entry in entries {
-        let entry = entry?;
-        unsafe {
-            assert_eq!(
-                entry.file_name(utf8_decoder)?,
-                entry.file_name(utf8_decoder)?
-            )
-        }
-    }
+    Archive::open(zip_archive()).entries(|entry| {
+        assert_eq!(
+            entry.file_name(utf8_decoder)?,
+            entry.file_name(utf8_decoder)?
+        );
+        Ok(())
+    })?;
     Ok(())
 }

--- a/src/archive_reader/blocks.rs
+++ b/src/archive_reader/blocks.rs
@@ -49,7 +49,7 @@ unsafe impl Send for BlockReaderBorrowed {}
 
 impl From<&Entries> for BlockReaderBorrowed {
     fn from(entries: &Entries) -> Self {
-        BlockReaderBorrowed::new(entries.0)
+        BlockReaderBorrowed::new(entries.archive)
     }
 }
 

--- a/src/archive_reader/blocks.rs
+++ b/src/archive_reader/blocks.rs
@@ -61,6 +61,13 @@ impl BlockReaderBorrowed {
         }
     }
 
+    pub(crate) fn empty() -> Self {
+        Self {
+            archive: std::ptr::null_mut(),
+            ended: true,
+        }
+    }
+
     pub(crate) fn read_block(&mut self) -> Result<&[u8]> {
         if self.ended {
             return Ok(&[]);

--- a/src/archive_reader/entries.rs
+++ b/src/archive_reader/entries.rs
@@ -94,7 +94,7 @@ impl Entries {
         info!(r#"Entries::find_entry_by_name(decoder: _, file_name: "{file_name}")"#);
         for item in self.by_ref() {
             match item {
-                Ok(entry) if unsafe { entry.file_name(decoder)? } == file_name => return Ok(()),
+                Ok(entry) if entry.file_name(decoder)? == file_name => return Ok(()),
                 Err(error) => return Err(error),
                 _ => (),
             }
@@ -121,7 +121,7 @@ impl Iterator for EntryNames {
 
     fn next(&mut self) -> Option<Self::Item> {
         let name = match self.entries.next()? {
-            Ok(entry) => unsafe { entry.file_name(self.decoder) }.map(String::from),
+            Ok(entry) => entry.file_name(self.decoder).map(String::from),
             Err(error) => Err(error),
         };
         Some(name)

--- a/src/archive_reader/entries.rs
+++ b/src/archive_reader/entries.rs
@@ -5,29 +5,67 @@ use log::{debug, error, info};
 use std::ffi::CString;
 use std::path::Path;
 
-pub(crate) struct Entries(pub(crate) *mut libarchive::archive);
+#[cfg(feature = "lending_iter")]
+use crate::LendingIterator;
+
+#[cfg(not(feature = "lending_iter"))]
+pub(crate) struct Entries {
+    pub(crate) archive: *mut libarchive::archive,
+}
+
+#[cfg(feature = "lending_iter")]
+pub(crate) struct Entries {
+    pub(crate) archive: *mut libarchive::archive,
+    pub(crate) entry: Option<Entry>,
+}
 
 unsafe impl Send for Entries {}
 
+#[cfg(not(feature = "lending_iter"))]
 impl Iterator for Entries {
     type Item = Result<Entry>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let entry = unsafe { self.read_entry() }?;
+        match entry {
+            Ok(entry) => Some(Ok(Entry::new(self.archive, entry))),
+            Err(error) => Some(Err(error)),
+        }
+    }
+}
+
+#[cfg(feature = "lending_iter")]
+impl LendingIterator for Entries {
+    type Item<'me> = Result<&'me mut Entry>;
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        let entry = unsafe { self.read_entry() }?;
+        let entry = match entry {
+            Err(error) => return Some(Err(error)),
+            Ok(entry) => Entry::new(self.archive, entry),
+        };
+        self.entry.replace(entry);
+        self.entry.as_mut().map(Ok)
+    }
+}
+
+impl Entries {
+    unsafe fn read_entry(&self) -> Option<Result<*mut libarchive::archive_entry>> {
         let mut entry = std::ptr::null_mut();
-        match unsafe { libarchive::archive_read_next_header(self.0, &mut entry) } {
+        match libarchive::archive_read_next_header(self.archive, &mut entry) {
             libarchive::ARCHIVE_EOF => {
                 debug!("archive_read_next_header: reaches EOF");
                 return None;
             }
             result => {
-                if let Err(error) = analyze_result(result, self.0) {
+                if let Err(error) = analyze_result(result, self.archive) {
                     error!("archive_read_next_header error: {error:?}");
                     return Some(Err(error));
                 }
                 debug!("archive_read_next_header: success");
             }
         };
-        Some(Ok(Entry::new(self.0, entry)))
+        Some(Ok(entry))
     }
 }
 
@@ -42,7 +80,11 @@ impl Entries {
         );
         Self::path_exists(archive_path)?;
         let archive = Self::create_handle(archive_path, block_size)?;
-        Ok(Entries(archive))
+        Ok(Entries {
+            archive,
+            #[cfg(feature = "lending_iter")]
+            entry: None,
+        })
     }
 
     fn path_exists(archive_path: &Path) -> Result<()> {
@@ -74,8 +116,8 @@ impl Entries {
     fn clean(&self) -> Result<()> {
         info!("Entries::clean()");
         unsafe {
-            analyze_result(libarchive::archive_read_close(self.0), self.0)?;
-            analyze_result(libarchive::archive_read_free(self.0), self.0)
+            analyze_result(libarchive::archive_read_close(self.archive), self.archive)?;
+            analyze_result(libarchive::archive_read_free(self.archive), self.archive)
         }
     }
 
@@ -92,7 +134,7 @@ impl Entries {
 
     pub(crate) fn find_entry_by_name(&mut self, file_name: &str, decoder: Decoder) -> Result<()> {
         info!(r#"Entries::find_entry_by_name(decoder: _, file_name: "{file_name}")"#);
-        for item in self.by_ref() {
+        while let Some(item) = self.next() {
             match item {
                 Ok(entry) if entry.file_name(decoder)? == file_name => return Ok(()),
                 Err(error) => return Err(error),

--- a/src/archive_reader/entry.rs
+++ b/src/archive_reader/entry.rs
@@ -19,6 +19,7 @@ use std::io::Write;
 pub struct Entry {
     archive: *mut libarchive::archive,
     entry: *mut libarchive::archive_entry,
+    already_read: bool,
 }
 
 unsafe impl Send for Entry {}
@@ -28,23 +29,23 @@ impl Entry {
         archive: *mut libarchive::archive,
         entry: *mut libarchive::archive_entry,
     ) -> Self {
-        Self { archive, entry }
+        Self {
+            archive,
+            entry,
+            already_read: false,
+        }
     }
 
     /// `file_name` returns the name of the entry decoded with the provided decoder.
     /// It may fail if the decoder cannot decode the name.
-    ///
-    /// # Safety
-    /// Make sure the Entries::next has not been called again before calling.
-    /// Calling this function while Entry is not pointing to the newest entry contains UB.
-    pub unsafe fn file_name<F>(&self, decode: F) -> Result<Cow<str>>
+    pub fn file_name<F>(&self, decode: F) -> Result<Cow<str>>
     where
         F: FnOnce(&[u8]) -> Option<Cow<str>>,
     {
         info!(r#"Entry::file_name(decode: _)"#);
         let _utf8_locale_guard = UTF8LocaleGuard::new();
 
-        let entry_name = libarchive::archive_entry_pathname(self.entry);
+        let entry_name = unsafe { libarchive::archive_entry_pathname(self.entry) };
         if entry_name.is_null() {
             error!("archive_entry_pathname returns null");
             return Err(std::io::Error::new(
@@ -53,7 +54,7 @@ impl Entry {
             )
             .into());
         }
-        let entry_name_in_bytes = CStr::from_ptr(entry_name).to_bytes();
+        let entry_name_in_bytes = unsafe { CStr::from_ptr(entry_name).to_bytes() };
         match decode(entry_name_in_bytes) {
             Some(entry_name) => Ok(entry_name),
             None => {
@@ -64,36 +65,37 @@ impl Entry {
     }
 
     /// `read_file_by_block` returns an iterator of the entry content blocks.
-    ///
-    /// # Safety
-    /// Make sure the Entries::next has not been called again before calling.
-    /// Calling this function while Entry is not pointing to the newest entry contains UB.
     #[cfg(not(feature = "lending_iter"))]
-    pub unsafe fn read_file_by_block(self) -> impl Iterator<Item = Result<Box<[u8]>>> + Send {
+    pub fn read_file_by_block(&mut self) -> impl Iterator<Item = Result<Box<[u8]>>> + Send {
         info!(r#"Entry::read_file_by_block()"#);
-        BlockReaderBorrowed::new(self.archive)
+        if self.already_read {
+            BlockReaderBorrowed::empty()
+        } else {
+            self.already_read = true;
+            BlockReaderBorrowed::new(self.archive)
+        }
     }
 
     /// `read_file_by_block` returns an iterator of the entry content blocks.
-    ///
-    /// # Safety
-    /// Make sure the Entries::next has not been called again before calling.
-    /// Calling this function while Entry is not pointing to the newest entry contains UB.
     #[cfg(feature = "lending_iter")]
-    pub unsafe fn read_file_by_block(
-        self,
+    pub fn read_file_by_block(
+        &mut self,
     ) -> impl for<'a> crate::LendingIterator<Item<'a> = Result<&'a [u8]>> + Send {
         info!(r#"Entry::read_file_by_block()"#);
-        BlockReaderBorrowed::new(self.archive)
+        if self.already_read {
+            BlockReaderBorrowed::empty()
+        } else {
+            self.already_read = true;
+            BlockReaderBorrowed::new(self.archive)
+        }
     }
 
     /// `read_file` reads the content of this entry to an output.
-    ///
-    /// # Safety
-    /// Make sure the Entries::next has not been called again before calling.
-    /// Calling this function while Entry is not pointing to the newest entry contains UB.
-    pub unsafe fn read_file<W: Write>(self, mut output: W) -> Result<usize> {
+    pub fn read_file<W: Write>(&mut self, mut output: W) -> Result<usize> {
         info!(r#"Entry::read_file(output: _)"#);
+        if self.already_read {
+            return Ok(0);
+        }
         let mut blocks = BlockReaderBorrowed::new(self.archive);
         let mut written = 0;
         while let Some(block) = LendingIterator::next(&mut blocks) {


### PR DESCRIPTION
* Functions in `Entry` is safe now because only the latest `Entry` will be accessible.
    * In the non-lending-iter feature scenario, every `Entry` is passed into a callback closure as mutable references. This prevents the `Entry`s from being moved out of the closure.
    * In the lending-tier feature scenario, the lending iterator guarantees the references cannot be moved.
* Reading an entry file content more than once will silently return. This matches with the behaviour when reading a file from EOF.