### PR TITLE
Remove decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archive-reader"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 authors = ["Yaxin Cheng <yaxin.cheng@icloud.com>"]
 license = "MIT"
@@ -17,6 +17,7 @@ exclude = ["test_resources", "src/archive_reader/archive_tests.rs"]
 thiserror = "1.0"
 log = "0.4"
 libc = "0.2"
+bytes = "1"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It provides rustic interface over listing file names and reading given files wit
 
 ```toml
 [dependencies]
-archive-reader = "0.3"
+archive-reader = "0.4"
 ```
 
 # Example

--- a/src/archive_reader/archive.rs
+++ b/src/archive_reader/archive.rs
@@ -2,7 +2,6 @@ use crate::archive_reader::blocks::{BlockReader, BlockReaderBorrowed};
 use crate::archive_reader::entries::Entries;
 use crate::error::Result;
 use crate::Entry;
-use bytes::Bytes;
 use log::info;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -55,8 +54,9 @@ impl Archive {
 // Consumers
 impl Archive {
     /// `list_file_names` return an iterator of file names extracted from the archive.
-    /// The file names are decoded using the decoder.
-    pub fn list_file_names(&self) -> Result<impl Iterator<Item = Result<Bytes>> + Send> {
+    /// The file names are in bytes,
+    /// and users can choose their own decoder to decode the bytes into string.
+    pub fn list_file_names(&self) -> Result<impl Iterator<Item = Result<bytes::Bytes>> + Send> {
         info!("Archive::list_file_names()");
         self.list_entries().map(|entries| entries.file_names())
     }
@@ -86,7 +86,7 @@ impl Archive {
     pub fn read_file_by_block<P>(
         &self,
         predicate: P,
-    ) -> Result<impl Iterator<Item = Result<Bytes>> + Send>
+    ) -> Result<impl Iterator<Item = Result<bytes::Bytes>> + Send>
     where
         P: Fn(&[u8]) -> bool,
     {
@@ -106,7 +106,7 @@ impl Archive {
     where
         P: Fn(&[u8]) -> bool,
     {
-        info!(r#"Archive::read_file_by_block(file_name: "{file_name}")"#);
+        info!(r#"Archive::read_file_by_block(predicate: _)"#);
         let mut entries = self.list_entries()?;
         entries.find_entry_by_name(predicate)?;
         Ok(BlockReader::new(entries))

--- a/src/archive_reader/archive.rs
+++ b/src/archive_reader/archive.rs
@@ -1,9 +1,9 @@
 use crate::archive_reader::blocks::{BlockReader, BlockReaderBorrowed};
 use crate::archive_reader::entries::Entries;
 use crate::error::Result;
-use crate::{Decoder, Entry};
+use crate::Entry;
+use bytes::Bytes;
 use log::info;
-use std::borrow::Cow;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -19,9 +19,6 @@ pub struct Archive {
     block_size: usize,
     /// `file_path` is the path to the target archive.
     file_path: PathBuf,
-    /// `decoder` is a function that decodes bytes into a proper string.
-    /// By default, it decodes using UTF8.
-    decoder: Option<Decoder>,
 }
 
 impl Archive {
@@ -34,7 +31,6 @@ impl Archive {
         Archive {
             block_size: DEFAULT_BLOCK_SIZE,
             file_path: path.as_ref().into(),
-            decoder: None,
         }
     }
 
@@ -54,42 +50,26 @@ impl Archive {
     pub fn reset_block_size(&mut self) -> &mut Self {
         self.block_size(DEFAULT_BLOCK_SIZE)
     }
-
-    /// `decoding_fn` sets a function as the decoder.
-    ///
-    /// # Note:
-    /// A decoder is a function that converts a series of bytes into a proper string.
-    /// In the case where the conversion failed, it should return `None`.
-    pub fn decoder(&mut self, function: Decoder) -> &mut Self {
-        self.decoder = Some(function);
-        self
-    }
-
-    /// `reset_decoder` resets the decoder back to the default decoder.
-    /// The default decoder converts the bytes into an UTF-8 encoded string.
-    /// Any inconvertible characters will be replaced with a
-    /// U+FFFD REPLACEMENT CHARACTER, which looks like this: �.
-    pub fn reset_decoder(&mut self) -> &mut Self {
-        self.decoder = None;
-        self
-    }
 }
 
 // Consumers
 impl Archive {
     /// `list_file_names` return an iterator of file names extracted from the archive.
     /// The file names are decoded using the decoder.
-    pub fn list_file_names(&self) -> Result<impl Iterator<Item = Result<String>> + Send> {
+    pub fn list_file_names(&self) -> Result<impl Iterator<Item = Result<Bytes>> + Send> {
         info!("Archive::list_file_names()");
         self.list_entries().map(|entries| entries.file_names())
     }
 
     /// `read_file` reads the content of a file into the given output.
     /// It also returns the total number of bytes read.
-    pub fn read_file<W: Write>(&self, file_name: &str, mut output: W) -> Result<usize> {
-        info!(r#"Archive::read_file(file_name: "{file_name}", output: _)"#);
+    pub fn read_file<W: Write, P>(&self, predicate: P, mut output: W) -> Result<usize>
+    where
+        P: Fn(&[u8]) -> bool,
+    {
+        info!(r#"Archive::read_file(predicate: _, output: _)"#);
         let mut entries = self.list_entries()?;
-        entries.find_entry_by_name(file_name)?;
+        entries.find_entry_by_name(predicate)?;
         let mut blocks = BlockReaderBorrowed::from(&entries);
         let mut written = 0;
         while let Some(block) = crate::LendingIterator::next(&mut blocks) {
@@ -103,26 +83,32 @@ impl Archive {
     /// `read_file_by_block` reads the content of a file,
     /// and returns an iterator of the blocks.
     #[cfg(not(feature = "lending_iter"))]
-    pub fn read_file_by_block(
+    pub fn read_file_by_block<P>(
         &self,
-        file_name: &str,
-    ) -> Result<impl Iterator<Item = Result<Box<[u8]>>> + Send> {
-        info!(r#"Archive::read_file_by_block(file_name: "{file_name}")"#);
+        predicate: P,
+    ) -> Result<impl Iterator<Item = Result<Bytes>> + Send>
+    where
+        P: Fn(&[u8]) -> bool,
+    {
+        info!(r#"Archive::read_file_by_block(predicate: _)"#);
         let mut entries = self.list_entries()?;
-        entries.find_entry_by_name(file_name)?;
+        entries.find_entry_by_name(predicate)?;
         Ok(BlockReader::new(entries))
     }
 
     /// `read_file_by_block` reads the content of a file,
     /// and returns an iterator of the blocks.
     #[cfg(feature = "lending_iter")]
-    pub fn read_file_by_block(
+    pub fn read_file_by_block<P>(
         &self,
-        file_name: &str,
-    ) -> Result<impl for<'a> crate::LendingIterator<Item<'a> = Result<&'a [u8]>> + Send> {
+        predicate: P,
+    ) -> Result<impl for<'a> crate::LendingIterator<Item<'a> = Result<&'a [u8]>> + Send>
+    where
+        P: Fn(&[u8]) -> bool,
+    {
         info!(r#"Archive::read_file_by_block(file_name: "{file_name}")"#);
         let mut entries = self.list_entries()?;
-        entries.find_entry_by_name(file_name)?;
+        entries.find_entry_by_name(predicate)?;
         Ok(BlockReader::new(entries))
     }
 
@@ -159,26 +145,11 @@ impl Archive {
     }
 }
 
-// util functions
-impl Archive {
-    fn list_entries(&self) -> Result<Entries> {
-        Entries::open(&self.file_path, self.block_size, self.get_decoding_fn())
-    }
-
-    fn get_decoding_fn(&self) -> Decoder {
-        match self.decoder {
-            Some(decoding_fn) => decoding_fn,
-            None => Self::decode_utf8,
-        }
-    }
-
-    fn decode_utf8(bytes: &[u8]) -> Option<Cow<'_, str>> {
-        Some(String::from_utf8_lossy(bytes))
-    }
-}
-
 // accessor
 impl Archive {
+    fn list_entries(&self) -> Result<Entries> {
+        Entries::open(&self.file_path, self.block_size)
+    }
     /// `path` returns the archive file path.
     pub fn path(&self) -> &Path {
         &self.file_path

--- a/src/archive_reader/archive_tests.rs
+++ b/src/archive_reader/archive_tests.rs
@@ -1,5 +1,10 @@
 use crate::error::Result;
 use crate::Archive;
+use bytes::Bytes;
+
+fn find_file(file_name: &str) -> impl Fn(&[u8]) -> bool + '_ {
+    move |bytes| String::from_utf8_lossy(bytes) == file_name
+}
 
 const fn zip_archive() -> &'static str {
     concat!(env!("CARGO_MANIFEST_DIR"), "/test_resources/test.zip")
@@ -91,7 +96,7 @@ fn test_read_dir() -> Result<()> {
 
 fn test_read_file_to_bytes(archive_path: &str, content_path: &str, expected: &[u8]) -> Result<()> {
     let mut output = vec![];
-    let _ = Archive::open(archive_path).read_file(content_path, &mut output)?;
+    let _ = Archive::open(archive_path).read_file(find_file(content_path), &mut output)?;
     assert_eq!(output, expected);
     Ok(())
 }
@@ -112,7 +117,7 @@ fn test_read_by_blocks() -> Result<()> {
         "/test_resources/large.zip"
     ))
     .block_size(1024)
-    .read_file_by_block("large.txt")?;
+    .read_file_by_block(find_file("large.txt"))?;
     while let Some(block) = blocks.next() {
         let block = block?;
         num_of_blocks += 1;
@@ -128,8 +133,8 @@ fn test_read_by_blocks() -> Result<()> {
 fn test_file_names_from_entries() -> Result<()> {
     let mut names = vec![];
     Archive::open(zip_archive()).entries(|entry| {
-        let file_name = entry.file_name()?.to_string();
-        names.push(file_name);
+        let file_name = entry.file_name()?;
+        names.push(Bytes::copy_from_slice(file_name));
         Ok(())
     })?;
     let expected = [

--- a/src/archive_reader/archive_tests.rs
+++ b/src/archive_reader/archive_tests.rs
@@ -156,7 +156,7 @@ fn test_file_names_from_entries() -> Result<()> {
     let mut names = vec![];
     let mut entries = Archive::open(zip_archive()).entries()?;
     while let Some(entry) = entries.next() {
-        let file_name = entry?.file_name()?.to_string();
+        let file_name = Bytes::copy_from_slice(entry?.file_name()?);
         names.push(file_name);
     }
     let expected = [

--- a/src/archive_reader/blocks.rs
+++ b/src/archive_reader/blocks.rs
@@ -2,6 +2,7 @@ use super::entries::Entries;
 use crate::error::{analyze_result, Result};
 use crate::libarchive;
 use crate::LendingIterator;
+use bytes::Bytes;
 use log::{debug, error};
 use std::slice;
 
@@ -23,9 +24,9 @@ impl BlockReader {
 
 #[cfg(not(feature = "lending_iter"))]
 impl Iterator for BlockReader {
-    type Item = Result<Box<[u8]>>;
+    type Item = Result<Bytes>;
 
-    fn next(&mut self) -> Option<Result<Box<[u8]>>> {
+    fn next(&mut self) -> Option<Result<Bytes>> {
         Iterator::next(&mut self.block_reader)
     }
 }
@@ -99,12 +100,12 @@ impl BlockReaderBorrowed {
 }
 
 impl Iterator for BlockReaderBorrowed {
-    type Item = Result<Box<[u8]>>;
+    type Item = Result<Bytes>;
 
-    fn next(&mut self) -> Option<Result<Box<[u8]>>> {
+    fn next(&mut self) -> Option<Result<Bytes>> {
         match self.read_block() {
             Ok(&[]) => None,
-            block => Some(block.map(Box::from)),
+            block => Some(block.map(Bytes::copy_from_slice)),
         }
     }
 }

--- a/src/archive_reader/entry.rs
+++ b/src/archive_reader/entry.rs
@@ -3,7 +3,6 @@ use crate::error::Result;
 use crate::lending_iter::LendingIterator;
 use crate::libarchive;
 use crate::locale::UTF8LocaleGuard;
-use bytes::Bytes;
 use log::{error, info};
 use std::ffi::CStr;
 use std::io::Write;
@@ -49,7 +48,7 @@ impl Entry {
 
     /// `read_file_by_block` returns an iterator of the entry content blocks.
     #[cfg(not(feature = "lending_iter"))]
-    pub fn read_file_by_block(&mut self) -> impl Iterator<Item = Result<Bytes>> + Send {
+    pub fn read_file_by_block(&mut self) -> impl Iterator<Item = Result<bytes::Bytes>> + Send {
         info!(r#"Entry::read_file_by_block()"#);
         if self.already_read {
             BlockReaderBorrowed::empty()

--- a/src/archive_reader/entry.rs
+++ b/src/archive_reader/entry.rs
@@ -1,10 +1,10 @@
 use super::blocks::BlockReaderBorrowed;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::lending_iter::LendingIterator;
+use crate::libarchive;
 use crate::locale::UTF8LocaleGuard;
-use crate::{libarchive, Decoder};
+use bytes::Bytes;
 use log::{error, info};
-use std::borrow::Cow;
 use std::ffi::CStr;
 use std::io::Write;
 
@@ -13,7 +13,6 @@ pub struct Entry {
     archive: *mut libarchive::archive,
     entry: *mut libarchive::archive_entry,
     already_read: bool,
-    decoder: Decoder,
 }
 
 unsafe impl Send for Entry {}
@@ -22,19 +21,17 @@ impl Entry {
     pub(crate) fn new(
         archive: *mut libarchive::archive,
         entry: *mut libarchive::archive_entry,
-        decoder: Decoder,
     ) -> Self {
         Self {
             archive,
             entry,
             already_read: false,
-            decoder,
         }
     }
 
     /// `file_name` returns the name of the entry decoded with the provided decoder.
     /// It may fail if the decoder cannot decode the name.
-    pub fn file_name(&self) -> Result<Cow<str>> {
+    pub fn file_name(&self) -> Result<&[u8]> {
         info!(r#"Entry::file_name()"#);
         let _utf8_locale_guard = UTF8LocaleGuard::new();
 
@@ -47,19 +44,12 @@ impl Entry {
             )
             .into());
         }
-        let entry_name_in_bytes = unsafe { CStr::from_ptr(entry_name).to_bytes() };
-        match (self.decoder)(entry_name_in_bytes) {
-            Some(entry_name) => Ok(entry_name),
-            None => {
-                error!("failed to decode entry name");
-                Err(Error::Encoding)
-            }
-        }
+        unsafe { Ok(CStr::from_ptr(entry_name).to_bytes()) }
     }
 
     /// `read_file_by_block` returns an iterator of the entry content blocks.
     #[cfg(not(feature = "lending_iter"))]
-    pub fn read_file_by_block(&mut self) -> impl Iterator<Item = Result<Box<[u8]>>> + Send {
+    pub fn read_file_by_block(&mut self) -> impl Iterator<Item = Result<Bytes>> + Send {
         info!(r#"Entry::read_file_by_block()"#);
         if self.already_read {
             BlockReaderBorrowed::empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!                         .list_file_names()?
 //!                         .collect::<Result<Vec<_>>>()?;
 //!     let mut content = vec![];
-//!     let _ = archive.read_file(&file_names[0], &mut content)?;
+//!     let _ = archive.read_file(|file_name_bytes| file_name_bytes == &file_names[0], &mut content)?;
 //!     println!("content={content:?}");
 //!     Ok(())
 //! }
@@ -36,5 +36,3 @@ pub use error::*;
 pub use lending_iter::LendingIterator;
 #[cfg(not(feature = "lending_iter"))]
 use lending_iter::LendingIterator;
-
-type Decoder = fn(&[u8]) -> Option<std::borrow::Cow<'_, str>>;


### PR DESCRIPTION
* Removing `Decoder` from the library. `file_name()` function will simply return the bytes of the entry name. Users have the option to decode the bytes in whatever way they want.
* In the default feature, all file content iterator is `bytes::Bytes` instead of `Vec<u8>` or `Box<[u8]>` for better user experiences.