### PR TITLE
Safety upgrade: guard `Entries` and `Entry` with lifetime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = ["test_resources", "src/archive_reader/archive_tests.rs"]
 thiserror = "1.0"
 log = "0.4"
 libc = "0.2"
-bytes = "1"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archive-reader"
-version = "0.4.0"
+version = "0.3.4"
 edition = "2021"
 authors = ["Yaxin Cheng <yaxin.cheng@icloud.com>"]
 license = "MIT"

--- a/src/archive_reader/archive.rs
+++ b/src/archive_reader/archive.rs
@@ -109,7 +109,7 @@ impl Archive {
     pub fn read_file_by_block(
         &self,
         file_name: &str,
-    ) -> Result<impl Iterator<Item = Result<bytes::Bytes>> + Send> {
+    ) -> Result<impl Iterator<Item = Result<Box<[u8]>>> + Send> {
         info!(r#"Archive::read_file_by_block(file_name: "{file_name}")"#);
         let mut entries = self.list_entries()?;
         entries.find_entry_by_name(file_name)?;

--- a/src/archive_reader/archive.rs
+++ b/src/archive_reader/archive.rs
@@ -121,11 +121,12 @@ impl Archive {
     #[cfg(not(feature = "lending_iter"))]
     pub fn entries<F>(&self, mut process: F) -> Result<()>
     where
-        F: FnMut(&mut Entry) -> Result<()>,
+        F: FnMut(Entry) -> Result<()>,
     {
         info!(r#"Archive::entries(process: _)"#);
-        for entry in self.list_entries()? {
-            process(&mut entry?)?
+        let mut entries = self.list_entries()?;
+        while let Some(entry) = entries.next() {
+            process(entry?)?
         }
         Ok(())
     }
@@ -139,7 +140,7 @@ impl Archive {
     #[cfg(feature = "lending_iter")]
     pub fn entries(
         &self,
-    ) -> Result<impl for<'a> crate::LendingIterator<Item<'a> = Result<&'a mut Entry>>> {
+    ) -> Result<impl for<'a> crate::LendingIterator<Item<'a> = Result<Entry<'a>>>> {
         info!(r#"Archive::entries()"#);
         self.list_entries()
     }

--- a/src/archive_reader/archive_tests.rs
+++ b/src/archive_reader/archive_tests.rs
@@ -174,7 +174,7 @@ fn test_file_names_from_entries() -> Result<()> {
 #[cfg(not(feature = "lending_iter"))]
 fn test_file_content_from_entries() -> Result<()> {
     let mut all_content = vec![];
-    Archive::open(zip_archive()).entries(|entry| {
+    Archive::open(zip_archive()).entries(|mut entry| {
         let mut content = Vec::<u8>::new();
         let mut blocks = entry.read_file_by_block();
         while let Some(block) = blocks.next() {

--- a/src/archive_reader/blocks.rs
+++ b/src/archive_reader/blocks.rs
@@ -62,13 +62,6 @@ impl BlockReaderBorrowed {
         }
     }
 
-    pub(crate) fn empty() -> Self {
-        Self {
-            archive: std::ptr::null_mut(),
-            ended: true,
-        }
-    }
-
     pub(crate) fn read_block(&mut self) -> Result<&[u8]> {
         if self.ended {
             return Ok(&[]);

--- a/src/archive_reader/blocks.rs
+++ b/src/archive_reader/blocks.rs
@@ -49,18 +49,14 @@ unsafe impl Send for BlockReaderBorrowed {}
 
 impl From<&Entries> for BlockReaderBorrowed {
     fn from(entries: &Entries) -> Self {
-        BlockReaderBorrowed::new(entries.archive)
+        Self {
+            archive: entries.archive,
+            ended: false,
+        }
     }
 }
 
 impl BlockReaderBorrowed {
-    pub(crate) fn new(archive: *mut libarchive::archive) -> Self {
-        Self {
-            archive,
-            ended: false,
-        }
-    }
-
     pub(crate) fn read_block(&mut self) -> Result<&[u8]> {
         if self.ended {
             return Ok(&[]);

--- a/src/archive_reader/blocks.rs
+++ b/src/archive_reader/blocks.rs
@@ -23,9 +23,9 @@ impl BlockReader {
 
 #[cfg(not(feature = "lending_iter"))]
 impl Iterator for BlockReader {
-    type Item = Result<bytes::Bytes>;
+    type Item = Result<Box<[u8]>>;
 
-    fn next(&mut self) -> Option<Result<bytes::Bytes>> {
+    fn next(&mut self) -> Option<Result<Box<[u8]>>> {
         Iterator::next(&mut self.block_reader)
     }
 }
@@ -88,12 +88,12 @@ impl BlockReaderBorrowed {
 }
 
 impl Iterator for BlockReaderBorrowed {
-    type Item = Result<bytes::Bytes>;
+    type Item = Result<Box<[u8]>>;
 
-    fn next(&mut self) -> Option<Result<bytes::Bytes>> {
+    fn next(&mut self) -> Option<Result<Box<[u8]>>> {
         match self.read_block() {
             Ok(&[]) => None,
-            block => Some(block.map(bytes::Bytes::copy_from_slice)),
+            block => Some(block.map(Box::from)),
         }
     }
 }

--- a/src/archive_reader/entries.rs
+++ b/src/archive_reader/entries.rs
@@ -81,9 +81,7 @@ impl Entries {
     fn path_exists(archive_path: &Path) -> Result<()> {
         if !archive_path.exists() {
             error!(r#"path "{}" does not exist"#, archive_path.display());
-            return Err(path_does_not_exist(
-                archive_path.to_string_lossy().to_string(),
-            ));
+            return Err(path_does_not_exist(archive_path.to_string_lossy()));
         }
         Ok(())
     }
@@ -126,7 +124,7 @@ impl Entries {
                 _ => (),
             }
         }
-        Err(path_does_not_exist("find_entry_failed".to_string()))
+        Err(path_does_not_exist(file_name))
     }
 }
 

--- a/src/archive_reader/entry.rs
+++ b/src/archive_reader/entry.rs
@@ -39,7 +39,7 @@ impl<'a> Entry<'a> {
 
     /// `read_file_by_block` returns an iterator of the entry content blocks.
     #[cfg(not(feature = "lending_iter"))]
-    pub fn read_file_by_block(&mut self) -> impl Iterator<Item = Result<bytes::Bytes>> + Send {
+    pub fn read_file_by_block(self) -> impl Iterator<Item = Result<bytes::Bytes>> + Send + 'a {
         info!(r#"Entry::read_file_by_block()"#);
         BlockReaderBorrowed::new(self.entries.archive)
     }
@@ -48,7 +48,7 @@ impl<'a> Entry<'a> {
     #[cfg(feature = "lending_iter")]
     pub fn read_file_by_block(
         self,
-    ) -> impl for<'b> LendingIterator<Item<'b> = Result<&'b [u8]>> + Send {
+    ) -> impl for<'b> LendingIterator<Item<'b> = Result<&'b [u8]>> + Send + 'a {
         info!(r#"Entry::read_file_by_block()"#);
         BlockReaderBorrowed::new(self.entries.archive)
     }

--- a/src/archive_reader/entry.rs
+++ b/src/archive_reader/entry.rs
@@ -43,7 +43,7 @@ impl<'a> Entry<'a> {
 
     /// `read_file_by_block` returns an iterator of the entry content blocks.
     #[cfg(not(feature = "lending_iter"))]
-    pub fn read_file_by_block(self) -> impl Iterator<Item = Result<bytes::Bytes>> + Send + 'a {
+    pub fn read_file_by_block(self) -> impl Iterator<Item = Result<Box<[u8]>>> + Send + 'a {
         info!(r#"Entry::read_file_by_block()"#);
         BlockReaderBorrowed::from(self.entries)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,16 @@ pub(crate) fn analyze_result(
     }
 }
 
-pub(crate) fn path_does_not_exist(message: String) -> Error {
-    Error::Io(std::io::Error::new(std::io::ErrorKind::NotFound, message))
+pub(crate) fn path_does_not_exist<S: Into<String>>(message: S) -> Error {
+    Error::Io(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        message.into(),
+    ))
+}
+
+pub(crate) fn invalid_data<S: Into<String>>(message: S) -> Error {
+    Error::Io(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        message.into(),
+    ))
 }


### PR DESCRIPTION
* `Entry` cannot be moved out of the closure / loop when iterating through `Entries`
* The file block iterator generated by calls to `Entry::read_file_by_block` cannot be moved out of the closure / loop either
* `Entry` now keeps a reference to `Entries`, and its functions except the `file_name` will consume itself